### PR TITLE
Add missing libopenssl dep to openwrt build

### DIFF
--- a/openwrt/kismet-openwrt/kismet/Makefile
+++ b/openwrt/kismet-openwrt/kismet/Makefile
@@ -18,7 +18,7 @@ define Package/kismet
   CATEGORY:=Network
   TITLE:=Kismet 2023
   URL:=https://www.kismetwireless.net/
-  DEPENDS:=+libpthread +libpcap +libpcre2 +libstdcpp +libncurses +libsqlite3 +zlib +protobuf-lite +libprotobuf-c +libsensors
+  DEPENDS:=+libpthread +libpcap +libpcre2 +libstdcpp +libncurses +libsqlite3 +zlib +protobuf-lite +libprotobuf-c +libsensors +libopenssl
   SUBMENU:=kismet
 endef
 


### PR DESCRIPTION
When you want to compile the repo it currently throws this

```
 make[1] package/kismet/compile
 make[2] -C feeds/packages/lang/perl host-compile
 make[2] -C feeds/packages/libs/protobuf host-compile
 make[2] -C feeds/base/package/libs/ncurses host-compile
 make[2] -C feeds/packages/libs/protobuf-c host-compile
 make[2] -C package/toolchain compile
 make[2] -C feeds/packages/libs/gdbm compile
 make[2] -C feeds/base/package/libs/libpcap compile
 make[2] -C feeds/base/package/libs/sysfsutils compile
 make[2] -C feeds/base/package/libs/zlib compile
 make[2] -C feeds/base/package/libs/pcre2 compile
 make[2] -C feeds/base/package/libs/libxml2 compile
 make[2] -C feeds/packages/libs/protobuf compile
 make[2] -C feeds/base/package/libs/ncurses compile
 make[2] -C feeds/packages/libs/libedit compile
 make[2] -C feeds/packages/libs/db47 compile
 make[2] -C feeds/packages/libs/protobuf-c compile
 make[2] -C feeds/packages/libs/sqlite3 compile
 make[2] -C feeds/packages/lang/perl compile
 make[2] -C feeds/packages/utils/lm-sensors compile
 make[2] -C /home/dsr/Desktop/kismet-packages/openwrt/kismet-openwrt/kismet clean-build
 make[2] -C /home/dsr/Desktop/kismet-packages/openwrt/kismet-openwrt/kismet compile
    ERROR: package/feeds/kismet/kismet failed to build.
make -r package/kismet/compile: build failed. Please re-run make with -j1 V=s or V=sc for a higher verbosity level to see what's going on
make: *** [/home/dsr/Desktop/openwrt-sdk-23.05.3-ramips-mt7621/include/toplevel.mk:225: package/kismet/compile] Error 1
```

from what I see in the configure of the main repo openssl is mandatory to compile. So this was the change I made to be able to compile.
