### PR TITLE
Improve kismet group recommendation text

### DIFF
--- a/old-emulated-framework/scripts/fpm-2019-12-R1/debian/kismet.templates
+++ b/old-emulated-framework/scripts/fpm-2019-12-R1/debian/kismet.templates
@@ -3,13 +3,13 @@ Template: kismet-common/install-setuid
 Type: boolean
 Default: true
 Description: Should Kismet be installed with suid-root helpers?
- Kismet uses multiple helper programs to capture the packets.  Installing
- Kismet can be installed so that members of the "kismet" system group can
+ Kismet uses multiple helper programs to capture the packets. Kismet
+ can be installed so that members of the "kismet" system group can
  reconfigure network interfaces and capture packets.
  .
  This behavior is more secure, as it allows Kismet to operate without
  root privileges, except on specific tools.
- . 
+ .
  Running Kismet as root increases the risk if there is a security error in
  Kismet.
  .

--- a/old-emulated-framework/scripts/fpm-2019-12-R2/debian/kismet.templates
+++ b/old-emulated-framework/scripts/fpm-2019-12-R2/debian/kismet.templates
@@ -3,13 +3,13 @@ Template: kismet-common/install-setuid
 Type: boolean
 Default: true
 Description: Should Kismet be installed with suid-root helpers?
- Kismet uses multiple helper programs to capture the packets.  Installing
- Kismet can be installed so that members of the "kismet" system group can
+ Kismet uses multiple helper programs to capture the packets. Kismet
+can be installed so that members of the "kismet" system group can
  reconfigure network interfaces and capture packets.
  .
  This behavior is more secure, as it allows Kismet to operate without
  root privileges, except on specific tools.
- . 
+ .
  Running Kismet as root increases the risk if there is a security error in
  Kismet.
  .

--- a/old-emulated-framework/scripts/fpm-2020-03-R1/debian/kismet.templates
+++ b/old-emulated-framework/scripts/fpm-2020-03-R1/debian/kismet.templates
@@ -3,13 +3,13 @@ Template: kismet-common/install-setuid
 Type: boolean
 Default: true
 Description: Should Kismet be installed with suid-root helpers?
- Kismet uses multiple helper programs to capture the packets.  Installing
- Kismet can be installed so that members of the "kismet" system group can
+ Kismet uses multiple helper programs to capture the packets. Kismet
+can be installed so that members of the "kismet" system group can
  reconfigure network interfaces and capture packets.
  .
  This behavior is more secure, as it allows Kismet to operate without
  root privileges, except on specific tools.
- . 
+ .
  Running Kismet as root increases the risk if there is a security error in
  Kismet.
  .

--- a/old-emulated-framework/scripts/fpm-2020-04-R1/debian/kismet.templates
+++ b/old-emulated-framework/scripts/fpm-2020-04-R1/debian/kismet.templates
@@ -3,13 +3,13 @@ Template: kismet-common/install-setuid
 Type: boolean
 Default: true
 Description: Should Kismet be installed with suid-root helpers?
- Kismet uses multiple helper programs to capture the packets.  Installing
- Kismet can be installed so that members of the "kismet" system group can
+ Kismet uses multiple helper programs to capture the packets. Kismet
+can be installed so that members of the "kismet" system group can
  reconfigure network interfaces and capture packets.
  .
  This behavior is more secure, as it allows Kismet to operate without
  root privileges, except on specific tools.
- . 
+ .
  Running Kismet as root increases the risk if there is a security error in
  Kismet.
  .

--- a/old-emulated-framework/scripts/fpm-2020-04-R2/debian/kismet.templates
+++ b/old-emulated-framework/scripts/fpm-2020-04-R2/debian/kismet.templates
@@ -3,13 +3,13 @@ Template: kismet-common/install-setuid
 Type: boolean
 Default: true
 Description: Should Kismet be installed with suid-root helpers?
- Kismet uses multiple helper programs to capture the packets.  Installing
- Kismet can be installed so that members of the "kismet" system group can
+ Kismet uses multiple helper programs to capture the packets. Kismet
+can be installed so that members of the "kismet" system group can
  reconfigure network interfaces and capture packets.
  .
  This behavior is more secure, as it allows Kismet to operate without
  root privileges, except on specific tools.
- . 
+ .
  Running Kismet as root increases the risk if there is a security error in
  Kismet.
  .

--- a/old-emulated-framework/scripts/fpm-2020-04-R3/debian/kismet.templates
+++ b/old-emulated-framework/scripts/fpm-2020-04-R3/debian/kismet.templates
@@ -3,13 +3,13 @@ Template: kismet-common/install-setuid
 Type: boolean
 Default: true
 Description: Should Kismet be installed with suid-root helpers?
- Kismet uses multiple helper programs to capture the packets.  Installing
- Kismet can be installed so that members of the "kismet" system group can
+ Kismet uses multiple helper programs to capture the packets. Kismet
+can be installed so that members of the "kismet" system group can
  reconfigure network interfaces and capture packets.
  .
  This behavior is more secure, as it allows Kismet to operate without
  root privileges, except on specific tools.
- . 
+ .
  Running Kismet as root increases the risk if there is a security error in
  Kismet.
  .

--- a/old-emulated-framework/scripts/fpm-2020-09-R1/debian/kismet.templates
+++ b/old-emulated-framework/scripts/fpm-2020-09-R1/debian/kismet.templates
@@ -3,13 +3,13 @@ Template: kismet-common/install-setuid
 Type: boolean
 Default: true
 Description: Should Kismet be installed with suid-root helpers?
- Kismet uses multiple helper programs to capture the packets.  Installing
- Kismet can be installed so that members of the "kismet" system group can
+ Kismet uses multiple helper programs to capture the packets. Kismet
+can be installed so that members of the "kismet" system group can
  reconfigure network interfaces and capture packets.
  .
  This behavior is more secure, as it allows Kismet to operate without
  root privileges, except on specific tools.
- . 
+ .
  Running Kismet as root increases the risk if there is a security error in
  Kismet.
  .

--- a/old-emulated-framework/scripts/fpm-2020-09-R2/debian/kismet.templates
+++ b/old-emulated-framework/scripts/fpm-2020-09-R2/debian/kismet.templates
@@ -3,13 +3,13 @@ Template: kismet-common/install-setuid
 Type: boolean
 Default: true
 Description: Should Kismet be installed with suid-root helpers?
- Kismet uses multiple helper programs to capture the packets.  Installing
- Kismet can be installed so that members of the "kismet" system group can
+ Kismet uses multiple helper programs to capture the packets. Kismet
+can be installed so that members of the "kismet" system group can
  reconfigure network interfaces and capture packets.
  .
  This behavior is more secure, as it allows Kismet to operate without
  root privileges, except on specific tools.
- . 
+ .
  Running Kismet as root increases the risk if there is a security error in
  Kismet.
  .

--- a/old-emulated-framework/scripts/fpm-2020-09-R3/debian/kismet.templates
+++ b/old-emulated-framework/scripts/fpm-2020-09-R3/debian/kismet.templates
@@ -3,13 +3,13 @@ Template: kismet-common/install-setuid
 Type: boolean
 Default: true
 Description: Should Kismet be installed with suid-root helpers?
- Kismet uses multiple helper programs to capture the packets.  Installing
- Kismet can be installed so that members of the "kismet" system group can
+ Kismet uses multiple helper programs to capture the packets. Kismet
+can be installed so that members of the "kismet" system group can
  reconfigure network interfaces and capture packets.
  .
  This behavior is more secure, as it allows Kismet to operate without
  root privileges, except on specific tools.
- . 
+ .
  Running Kismet as root increases the risk if there is a security error in
  Kismet.
  .

--- a/old-emulated-framework/scripts/fpm-2020-09-R3a/debian/kismet.templates
+++ b/old-emulated-framework/scripts/fpm-2020-09-R3a/debian/kismet.templates
@@ -3,13 +3,13 @@ Template: kismet-common/install-setuid
 Type: boolean
 Default: true
 Description: Should Kismet be installed with suid-root helpers?
- Kismet uses multiple helper programs to capture the packets.  Installing
- Kismet can be installed so that members of the "kismet" system group can
+ Kismet uses multiple helper programs to capture the packets. Kismet
+can be installed so that members of the "kismet" system group can
  reconfigure network interfaces and capture packets.
  .
  This behavior is more secure, as it allows Kismet to operate without
  root privileges, except on specific tools.
- . 
+ .
  Running Kismet as root increases the risk if there is a security error in
  Kismet.
  .

--- a/old-emulated-framework/scripts/fpm-2020-09-R4/debian/kismet.templates
+++ b/old-emulated-framework/scripts/fpm-2020-09-R4/debian/kismet.templates
@@ -3,13 +3,13 @@ Template: kismet-common/install-setuid
 Type: boolean
 Default: true
 Description: Should Kismet be installed with suid-root helpers?
- Kismet uses multiple helper programs to capture the packets.  Installing
- Kismet can be installed so that members of the "kismet" system group can
+ Kismet uses multiple helper programs to capture the packets. Kismet
+can be installed so that members of the "kismet" system group can
  reconfigure network interfaces and capture packets.
  .
  This behavior is more secure, as it allows Kismet to operate without
  root privileges, except on specific tools.
- . 
+ .
  Running Kismet as root increases the risk if there is a security error in
  Kismet.
  .

--- a/old-emulated-framework/scripts/fpm-2020-12-R1/debian/kismet.templates
+++ b/old-emulated-framework/scripts/fpm-2020-12-R1/debian/kismet.templates
@@ -3,13 +3,13 @@ Template: kismet-common/install-setuid
 Type: boolean
 Default: true
 Description: Should Kismet be installed with suid-root helpers?
- Kismet uses multiple helper programs to capture the packets.  Installing
- Kismet can be installed so that members of the "kismet" system group can
+ Kismet uses multiple helper programs to capture the packets. Kismet
+can be installed so that members of the "kismet" system group can
  reconfigure network interfaces and capture packets.
  .
  This behavior is more secure, as it allows Kismet to operate without
  root privileges, except on specific tools.
- . 
+ .
  Running Kismet as root increases the risk if there is a security error in
  Kismet.
  .

--- a/old-emulated-framework/scripts/fpm-2020-12-R2/debian/kismet.templates
+++ b/old-emulated-framework/scripts/fpm-2020-12-R2/debian/kismet.templates
@@ -3,13 +3,13 @@ Template: kismet-common/install-setuid
 Type: boolean
 Default: true
 Description: Should Kismet be installed with suid-root helpers?
- Kismet uses multiple helper programs to capture the packets.  Installing
- Kismet can be installed so that members of the "kismet" system group can
+ Kismet uses multiple helper programs to capture the packets. Kismet
+can be installed so that members of the "kismet" system group can
  reconfigure network interfaces and capture packets.
  .
  This behavior is more secure, as it allows Kismet to operate without
  root privileges, except on specific tools.
- . 
+ .
  Running Kismet as root increases the risk if there is a security error in
  Kismet.
  .

--- a/old-emulated-framework/scripts/fpm-2020-12-R3/debian/kismet.templates
+++ b/old-emulated-framework/scripts/fpm-2020-12-R3/debian/kismet.templates
@@ -3,13 +3,13 @@ Template: kismet-common/install-setuid
 Type: boolean
 Default: true
 Description: Should Kismet be installed with suid-root helpers?
- Kismet uses multiple helper programs to capture the packets.  Installing
- Kismet can be installed so that members of the "kismet" system group can
+ Kismet uses multiple helper programs to capture the packets. Kismet
+can be installed so that members of the "kismet" system group can
  reconfigure network interfaces and capture packets.
  .
  This behavior is more secure, as it allows Kismet to operate without
  root privileges, except on specific tools.
- . 
+ .
  Running Kismet as root increases the risk if there is a security error in
  Kismet.
  .

--- a/old-emulated-framework/scripts/fpm-2020-12-R3a/debian/kismet.templates
+++ b/old-emulated-framework/scripts/fpm-2020-12-R3a/debian/kismet.templates
@@ -3,13 +3,13 @@ Template: kismet-common/install-setuid
 Type: boolean
 Default: true
 Description: Should Kismet be installed with suid-root helpers?
- Kismet uses multiple helper programs to capture the packets.  Installing
- Kismet can be installed so that members of the "kismet" system group can
+ Kismet uses multiple helper programs to capture the packets. Kismet
+can be installed so that members of the "kismet" system group can
  reconfigure network interfaces and capture packets.
  .
  This behavior is more secure, as it allows Kismet to operate without
  root privileges, except on specific tools.
- . 
+ .
  Running Kismet as root increases the risk if there is a security error in
  Kismet.
  .

--- a/old-emulated-framework/scripts/fpm-2021-05-R1/debian/kismet.templates
+++ b/old-emulated-framework/scripts/fpm-2021-05-R1/debian/kismet.templates
@@ -3,13 +3,13 @@ Template: kismet-common/install-setuid
 Type: boolean
 Default: true
 Description: Should Kismet be installed with suid-root helpers?
- Kismet uses multiple helper programs to capture the packets.  Installing
- Kismet can be installed so that members of the "kismet" system group can
+ Kismet uses multiple helper programs to capture the packets. Kismet
+can be installed so that members of the "kismet" system group can
  reconfigure network interfaces and capture packets.
  .
  This behavior is more secure, as it allows Kismet to operate without
  root privileges, except on specific tools.
- . 
+ .
  Running Kismet as root increases the risk if there is a security error in
  Kismet.
  .

--- a/old-emulated-framework/scripts/fpm-2021-06-R1/debian/kismet.templates
+++ b/old-emulated-framework/scripts/fpm-2021-06-R1/debian/kismet.templates
@@ -3,13 +3,13 @@ Template: kismet-common/install-setuid
 Type: boolean
 Default: true
 Description: Should Kismet be installed with suid-root helpers?
- Kismet uses multiple helper programs to capture the packets.  Installing
- Kismet can be installed so that members of the "kismet" system group can
+ Kismet uses multiple helper programs to capture the packets. Kismet
+can be installed so that members of the "kismet" system group can
  reconfigure network interfaces and capture packets.
  .
  This behavior is more secure, as it allows Kismet to operate without
  root privileges, except on specific tools.
- . 
+ .
  Running Kismet as root increases the risk if there is a security error in
  Kismet.
  .

--- a/old-emulated-framework/scripts/fpm-2021-08-R1/debian/kismet.templates
+++ b/old-emulated-framework/scripts/fpm-2021-08-R1/debian/kismet.templates
@@ -3,13 +3,13 @@ Template: kismet-common/install-setuid
 Type: boolean
 Default: true
 Description: Should Kismet be installed with suid-root helpers?
- Kismet uses multiple helper programs to capture the packets.  Installing
- Kismet can be installed so that members of the "kismet" system group can
+ Kismet uses multiple helper programs to capture the packets. Kismet
+can be installed so that members of the "kismet" system group can
  reconfigure network interfaces and capture packets.
  .
  This behavior is more secure, as it allows Kismet to operate without
  root privileges, except on specific tools.
- . 
+ .
  Running Kismet as root increases the risk if there is a security error in
  Kismet.
  .

--- a/old-emulated-framework/scripts/fpm-2022-01-R1/debian/kismet.templates
+++ b/old-emulated-framework/scripts/fpm-2022-01-R1/debian/kismet.templates
@@ -3,13 +3,13 @@ Template: kismet-common/install-setuid
 Type: boolean
 Default: true
 Description: Should Kismet be installed with suid-root helpers?
- Kismet uses multiple helper programs to capture the packets.  Installing
- Kismet can be installed so that members of the "kismet" system group can
+ Kismet uses multiple helper programs to capture the packets. Kismet
+can be installed so that members of the "kismet" system group can
  reconfigure network interfaces and capture packets.
  .
  This behavior is more secure, as it allows Kismet to operate without
  root privileges, except on specific tools.
- . 
+ .
  Running Kismet as root increases the risk if there is a security error in
  Kismet.
  .

--- a/old-emulated-framework/scripts/fpm-2022-01-R2/debian/kismet.templates
+++ b/old-emulated-framework/scripts/fpm-2022-01-R2/debian/kismet.templates
@@ -3,13 +3,13 @@ Template: kismet-common/install-setuid
 Type: boolean
 Default: true
 Description: Should Kismet be installed with suid-root helpers?
- Kismet uses multiple helper programs to capture the packets.  Installing
- Kismet can be installed so that members of the "kismet" system group can
+ Kismet uses multiple helper programs to capture the packets. Kismet
+can be installed so that members of the "kismet" system group can
  reconfigure network interfaces and capture packets.
  .
  This behavior is more secure, as it allows Kismet to operate without
  root privileges, except on specific tools.
- . 
+ .
  Running Kismet as root increases the risk if there is a security error in
  Kismet.
  .

--- a/old-emulated-framework/scripts/fpm-kismet-2020-09-R3/debian/kismet.templates
+++ b/old-emulated-framework/scripts/fpm-kismet-2020-09-R3/debian/kismet.templates
@@ -3,13 +3,13 @@ Template: kismet-common/install-setuid
 Type: boolean
 Default: true
 Description: Should Kismet be installed with suid-root helpers?
- Kismet uses multiple helper programs to capture the packets.  Installing
- Kismet can be installed so that members of the "kismet" system group can
+ Kismet uses multiple helper programs to capture the packets. Kismet
+can be installed so that members of the "kismet" system group can
  reconfigure network interfaces and capture packets.
  .
  This behavior is more secure, as it allows Kismet to operate without
  root privileges, except on specific tools.
- . 
+ .
  Running Kismet as root increases the risk if there is a security error in
  Kismet.
  .

--- a/old-emulated-framework/scripts/fpm-master/debian/kismet.templates
+++ b/old-emulated-framework/scripts/fpm-master/debian/kismet.templates
@@ -3,13 +3,13 @@ Template: kismet-common/install-setuid
 Type: boolean
 Default: true
 Description: Should Kismet be installed with suid-root helpers?
- Kismet uses multiple helper programs to capture the packets.  Installing
- Kismet can be installed so that members of the "kismet" system group can
+ Kismet uses multiple helper programs to capture the packets. Kismet
+can be installed so that members of the "kismet" system group can
  reconfigure network interfaces and capture packets.
  .
  This behavior is more secure, as it allows Kismet to operate without
  root privileges, except on specific tools.
- . 
+ .
  Running Kismet as root increases the risk if there is a security error in
  Kismet.
  .

--- a/scripts/fpm-2022-01-R3/debian/kismet.templates
+++ b/scripts/fpm-2022-01-R3/debian/kismet.templates
@@ -3,13 +3,13 @@ Template: kismet-common/install-setuid
 Type: boolean
 Default: true
 Description: Should Kismet be installed with suid-root helpers?
- Kismet uses multiple helper programs to capture the packets.  Installing
- Kismet can be installed so that members of the "kismet" system group can
+ Kismet uses multiple helper programs to capture the packets. Kismet
+can be installed so that members of the "kismet" system group can
  reconfigure network interfaces and capture packets.
  .
  This behavior is more secure, as it allows Kismet to operate without
  root privileges, except on specific tools.
- . 
+ .
  Running Kismet as root increases the risk if there is a security error in
  Kismet.
  .

--- a/scripts/fpm-2022-01-R3a/debian/kismet.templates
+++ b/scripts/fpm-2022-01-R3a/debian/kismet.templates
@@ -3,13 +3,13 @@ Template: kismet-common/install-setuid
 Type: boolean
 Default: true
 Description: Should Kismet be installed with suid-root helpers?
- Kismet uses multiple helper programs to capture the packets.  Installing
- Kismet can be installed so that members of the "kismet" system group can
+ Kismet uses multiple helper programs to capture the packets. Kismet
+can be installed so that members of the "kismet" system group can
  reconfigure network interfaces and capture packets.
  .
  This behavior is more secure, as it allows Kismet to operate without
  root privileges, except on specific tools.
- . 
+ .
  Running Kismet as root increases the risk if there is a security error in
  Kismet.
  .

--- a/scripts/fpm-2022-02-R1/debian/kismet.templates
+++ b/scripts/fpm-2022-02-R1/debian/kismet.templates
@@ -3,13 +3,13 @@ Template: kismet-common/install-setuid
 Type: boolean
 Default: true
 Description: Should Kismet be installed with suid-root helpers?
- Kismet uses multiple helper programs to capture the packets.  Installing
- Kismet can be installed so that members of the "kismet" system group can
+ Kismet uses multiple helper programs to capture the packets. Kismet
+can be installed so that members of the "kismet" system group can
  reconfigure network interfaces and capture packets.
  .
  This behavior is more secure, as it allows Kismet to operate without
  root privileges, except on specific tools.
- . 
+ .
  Running Kismet as root increases the risk if there is a security error in
  Kismet.
  .

--- a/scripts/fpm-2022-08-R1/debian/kismet.templates
+++ b/scripts/fpm-2022-08-R1/debian/kismet.templates
@@ -3,13 +3,13 @@ Template: kismet-common/install-setuid
 Type: boolean
 Default: true
 Description: Should Kismet be installed with suid-root helpers?
- Kismet uses multiple helper programs to capture the packets.  Installing
- Kismet can be installed so that members of the "kismet" system group can
+ Kismet uses multiple helper programs to capture the packets. Kismet
+can be installed so that members of the "kismet" system group can
  reconfigure network interfaces and capture packets.
  .
  This behavior is more secure, as it allows Kismet to operate without
  root privileges, except on specific tools.
- . 
+ .
  Running Kismet as root increases the risk if there is a security error in
  Kismet.
  .

--- a/scripts/fpm-2023-07-R1/debian/kismet.templates
+++ b/scripts/fpm-2023-07-R1/debian/kismet.templates
@@ -3,13 +3,13 @@ Template: kismet-common/install-setuid
 Type: boolean
 Default: true
 Description: Should Kismet be installed with suid-root helpers?
- Kismet uses multiple helper programs to capture the packets.  Installing
- Kismet can be installed so that members of the "kismet" system group can
+ Kismet uses multiple helper programs to capture the packets. Kismet
+can be installed so that members of the "kismet" system group can
  reconfigure network interfaces and capture packets.
  .
  This behavior is more secure, as it allows Kismet to operate without
  root privileges, except on specific tools.
- . 
+ .
  Running Kismet as root increases the risk if there is a security error in
  Kismet.
  .

--- a/scripts/fpm-master/debian/kismet.templates
+++ b/scripts/fpm-master/debian/kismet.templates
@@ -3,13 +3,13 @@ Template: kismet-common/install-setuid
 Type: boolean
 Default: true
 Description: Should Kismet be installed with suid-root helpers?
- Kismet uses multiple helper programs to capture the packets.  Installing
- Kismet can be installed so that members of the "kismet" system group can
+ Kismet uses multiple helper programs to capture the packets. Kismet
+can be installed so that members of the "kismet" system group can
  reconfigure network interfaces and capture packets.
  .
  This behavior is more secure, as it allows Kismet to operate without
  root privileges, except on specific tools.
- . 
+ .
  Running Kismet as root increases the risk if there is a security error in
  Kismet.
  .


### PR DESCRIPTION
Installing was in this sentence twice which made it difficult to read. Simplify it and remove the extra double space.