### PR TITLE
Fix capitalization of KillerBee + remove double spaces

### DIFF
--- a/centos/el7/kismet.spec
+++ b/centos/el7/kismet.spec
@@ -19,8 +19,8 @@ Conflicts: kismet-git
 
 %description
 Kismet is an 802.11 wireless network detector, sniffer, and intrusion
-detection system.  Kismet will work with any wireless card which 
-supports raw monitoring mode, and can sniff 802.11b, 802.11a, 802.11g, 
+detection system. Kismet will work with any wireless card which
+supports raw monitoring mode, and can sniff 802.11b, 802.11a, 802.11g,
 and 802.11n traffic (devices and drivers permitting).
 
 %prep

--- a/openwrt/kismet-openwrt/kismet-capture-rz-killerbee/Makefile
+++ b/openwrt/kismet-openwrt/kismet-capture-rz-killerbee/Makefile
@@ -9,14 +9,14 @@ include $(INCLUDE_DIR)/package.mk
 define Package/kismet-capture-rz-killerbee
   SECTION:=net
   CATEGORY:=Network
-  TITLE:=Kismet Killerbee Capture Support
+  TITLE:=Kismet KillerBee Capture Support
   URL:=https://www.kismetwireless.net
   DEPENDS:=+libpthread +libpcap +libnl +libcap +protobuf-lite +libprotobuf-c +libusb-1.0 
   SUBMENU:=kismet
 endef
 
 define Package/kismet-capture-rz-killerbee/description
-  Helper binary to capture Zigbee from a Killerbee adapter.
+  Helper binary to capture Zigbee from a KillerBee adapter.
   Enables local and remote 802.15.4 packet capture with Kismet
 endef
 

--- a/openwrt/kismet-openwrt/kismet-icao-database/Makefile
+++ b/openwrt/kismet-openwrt/kismet-icao-database/Makefile
@@ -17,8 +17,8 @@ endef
 
 define Package/kismet-icao-database/description
   Kismet ICAO airplane database
-  Compressed database of ICAO airplane registrations.  Without this
-  database, Kismet will not be able to resolve flight info for 
+  Compressed database of ICAO airplane registrations. Without this
+  database, Kismet will not be able to resolve flight info for
   airlines detected via ADSB.
 endef
 


### PR DESCRIPTION
- Killerbee -> KillerBee
- Don't use double spaces after sentences. It's an old typewriter thing: https://www.grammarly.com/blog/punctuation-capitalization/spaces-after-period/